### PR TITLE
Fix DarkReader

### DIFF
--- a/css.css
+++ b/css.css
@@ -216,8 +216,6 @@ body{
     list-style-type: none;
     margin-right: 0 auto;
     width: 28.5%;
-    border-style: solid;
-    border-width: 2px;
     text-align: justify;
 }
 
@@ -251,8 +249,6 @@ body{
     justify-content: center;
     color: white;
     width: 150px;
-    border-style: solid;
-    border-width: 2px;
     margin-left: 510px;
     margin-top: -290px;
     text-align: justify;
@@ -286,8 +282,6 @@ body{
     list-style-type: none;
     margin: 0 auto;
     width: 40%;
-    border-style: solid;
-    border-width: 2px;
     text-align: justify;
     margin-left: 30%;
 }


### PR DESCRIPTION
darkreader on the nove website is kinda fucked

without darkreader:

<img width="1896" height="616" alt="Image" src="https://github.com/user-attachments/assets/2fbb7718-469a-472e-ac56-3228fddfd14e" />

with darkreader:

<img width="1896" height="616" alt="Image" src="https://github.com/user-attachments/assets/a73e2e0b-1fc3-4dc1-96c1-e4b74ba07ec8" />

without borders darkreader

<img width="1896" height="616" alt="Image" src="https://github.com/user-attachments/assets/c5dce7de-11fb-4648-9e0f-8c8cb54980d1" />

without borders

<img width="1896" height="616" alt="Image" src="https://github.com/user-attachments/assets/b129673b-1a50-4ed9-9a6d-81f6fd0e9f3e" />

the borders server NO benifit (atleast from what i can see), so why are they there?

just remove the border it's a simple fix in the css
if you're somehow too lazy to accept the pr.
enable darkreader lock with
```html
<meta name="darkreader-lock">
```
in the head of every html page, or add it dynamically with js